### PR TITLE
The sampled value should be a boolean, not a string. Currently the result is that the trace is always sampled.

### DIFF
--- a/packages/zipkin-instrumentation-grpc/README.md
+++ b/packages/zipkin-instrumentation-grpc/README.md
@@ -1,5 +1,6 @@
-# zipkin-instrumentation-grpc
+# zipkin-instrumentation-grpc-wrd
 
+This lib contains just a bugfix for the sample flag on the library created by @lnshi's: zipkin-instrumentation-grpc.
 This lib is the interceptor for [Zipkin](https://github.com/openzipkin/zipkin) to intercept your [GRPC](https://github.com/grpc/grpc) calls(unary/stream).
 
 ## Project test status
@@ -138,6 +139,3 @@ This lib is the interceptor for [Zipkin](https://github.com/openzipkin/zipkin) t
   }
   ```
 
-## Maintainer
-
-Feel free to `@lnshi` on Github for any issue of this lib 🙂

--- a/packages/zipkin-instrumentation-grpc/package.json
+++ b/packages/zipkin-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "zipkin-instrumentation-grpc",
-  "version": "0.0.6",
+  "name": "zipkin-instrumentation-grpc-wrd",
+  "version": "0.0.1",
   "description": "Interceptor for instrumenting GRPC calls.",
   "main": "lib/index.js",
   "scripts": {

--- a/packages/zipkin-instrumentation-grpc/src/ZipkinGrpcInterceptor.js
+++ b/packages/zipkin-instrumentation-grpc/src/ZipkinGrpcInterceptor.js
@@ -61,10 +61,8 @@ class ZipkinGrpcInterceptor {
       return;
     }
 
-    let ctxSampled = grpcMetadataFromIncomingCtx.get('x-b3-sampled')[0];
-    if (!(ctxSampled in ['0', '1'])) {
-      ctxSampled = '0';
-    }
+    let ctxSampledAsString = grpcMetadataFromIncomingCtx.get('x-b3-sampled')[0];
+    let ctxSampled = ctxSampledAsString === '1' || ctxSampledAsString === 'true';
 
     const ctxTraceInfo = new TraceId({
       traceId: new Some(ctxTraceId),


### PR DESCRIPTION
When using a sample rate of 1%, I still saw traces from the nodejs application. After digging through it , it turns out that the sampled value is propagated as a string with either '0' or '1'. Further on in the trace of zipkin.js when the recordAnnotation is done it is checked with: if (!sampled) return;  A string is always truthy, so it will always sample.
This pull request transforms the incoming string into a boolean.